### PR TITLE
fix: display 0% when no task is open instead of NaN

### DIFF
--- a/prophecies/apps/frontend/src/components/UserTaskStatsCard.vue
+++ b/prophecies/apps/frontend/src/components/UserTaskStatsCard.vue
@@ -53,9 +53,7 @@ export default {
         .get()
     },
     statsAverageAllStats () {
-      const stats = this.getAverage(this.statsAllOpenTasks)
-      stats.progress /= (this.openTasks.length ?? 1)
-      return stats
+      return this.getAverage(this.statsAllOpenTasks)
     },
     statsAverageByTaskId () {
       return this.openTaskIds.reduce((acc, tId) => {

--- a/prophecies/apps/frontend/tests/unit/specs/components/UserTaskStatsCard.spec.js
+++ b/prophecies/apps/frontend/tests/unit/specs/components/UserTaskStatsCard.spec.js
@@ -4,6 +4,8 @@ import '@/store'
 import Core from '@/core'
 import Task from '@/models/Task'
 import User from '@/models/User'
+import TaskUserStatistics from '@/models/TaskUserStatistics'
+
 import UserTaskStatsCard from '@/components/UserTaskStatsCard'
 
 describe('UserTaskStatsCard', () => {
@@ -18,7 +20,7 @@ describe('UserTaskStatsCard', () => {
     const localVue = createLocalVue()
     // Configure the local vue with plugins
     const { i18n } = Core.init(localVue).useAll()
-    const propsData = { taskIds: ['1', '2'], userId: 'django' }
+    const propsData = { taskIds: ['1',  '3'], userId: 'django' }
     wrapper = shallowMount(UserTaskStatsCard, { localVue, propsData, i18n })
 
     await wrapper.vm.setup()
@@ -26,11 +28,11 @@ describe('UserTaskStatsCard', () => {
   it('should show the progress of all open task', async () => {
     const element = wrapper.find('task-stats-card-all-rounds-stub')
     const { progress, done, pending } = element.attributes()
-    expect(Number(done)).toBe(7)
-    expect(Number(pending)).toBe(98)
-    expect(Number(progress)).toBeCloseTo(3.33, 1)
-  })
-
+    expect(Number(done)).toBe(15)
+    expect(Number(pending)).toBe(290)
+    expect(Number(progress)).toBeCloseTo(11.76, 1)
+  }) 
+  
   it('should show the dropdown menu with "All open task" selected by default ', () => {
     const element = wrapper.find('.user-task-stats-card__dropdown')
     expect(element.attributes('selectedid')).toBe('0_all')
@@ -58,5 +60,29 @@ describe('UserTaskStatsCard', () => {
 
   it('has the title all records', () => {
     expect(wrapper.text()).toContain('All records')
+  })
+
+  it('has the title all records', () => {
+    expect(wrapper.text()).toContain('All records')
+  })
+
+  describe("User stats of user with no open task",()=>{
+    beforeEach(()=>{
+
+      Task.update({ where: '3', data: { status: 'CLOSED' } })
+      Task.update({ where: '1', data: { status: 'CLOSED' } })
+      const localVue = createLocalVue()
+      // Configure the local vue with plugins
+      const { i18n } = Core.init(localVue).useAll()
+      const propsData = { taskIds: ['1',  '3'], userId: 'django' }
+      wrapper = shallowMount(UserTaskStatsCard, { localVue, propsData, i18n })
+    })
+    it('should show 0 as progress for all open task dropdown item', async () => {
+      const element = wrapper.find('task-stats-card-all-rounds-stub')
+      const { progress, done, pending } = element.attributes()
+      expect(Number(done)).toBe(0)
+      expect(Number(pending)).toBe(0)
+      expect(Number(progress)).toBeCloseTo(0)
+    }) 
   })
 })

--- a/prophecies/apps/frontend/tests/unit/specs/components/UserTaskStatsCard.spec.js
+++ b/prophecies/apps/frontend/tests/unit/specs/components/UserTaskStatsCard.spec.js
@@ -4,7 +4,6 @@ import '@/store'
 import Core from '@/core'
 import Task from '@/models/Task'
 import User from '@/models/User'
-import TaskUserStatistics from '@/models/TaskUserStatistics'
 
 import UserTaskStatsCard from '@/components/UserTaskStatsCard'
 


### PR DESCRIPTION
When all tasks are closed we had a NaN showing up
![image](https://github.com/ICIJ/prophecies/assets/4643139/4c4947a0-023c-4ec6-8110-33b52b355c7e)

Now we display this:
![image](https://github.com/ICIJ/prophecies/assets/4643139/6500f166-e477-4430-9ecc-1585e981746c)