### PR TITLE
Fix : task record template and import/export 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -416,20 +416,20 @@ Django = ">=3.2"
 
 [[package]]
 name = "django-import-export"
-version = "3.0.2"
+version = "2.7.1"
 description = "Django application and library for importing and exporting data with included admin integration."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "django-import-export-3.0.2.tar.gz", hash = "sha256:ae77a44c08d94b98e50dec11ea53fd5f65702b7d8c3c929c88c310a4e4444507"},
-    {file = "django_import_export-3.0.2-py3-none-any.whl", hash = "sha256:f0f08f119b1f3a39e67dab8f945609ee13e264a798be532bdd7210e1c851efe2"},
+    {file = "django-import-export-2.7.1.tar.gz", hash = "sha256:4bc65943a5ce66aeaf2b5d0d6f75b1863b63b10323bf235e46500bef5d6dd85b"},
+    {file = "django_import_export-2.7.1-py3-none-any.whl", hash = "sha256:254ca359782efca932c398edabc15dd51d31da241e85cc03af5b720173e0b2fe"},
 ]
 
 [package.dependencies]
 diff-match-patch = "*"
-Django = ">=3.2"
-tablib = {version = ">=3.2.1", extras = ["html", "ods", "xls", "xlsx", "yaml"]}
+Django = ">=2.2"
+tablib = {version = ">=3.0.0", extras = ["html", "ods", "xls", "xlsx", "yaml"]}
 
 [[package]]
 name = "django-jsonfield"
@@ -1589,4 +1589,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e01a37f7bc6b42d6da03e2a6033d733214e4c4e57acfec94bee025a7ffc45729"
+content-hash = "324719f64e4b450de7417533e0de85c079f570b9e67f4b5529d7996b81f051d6"

--- a/prophecies/core/templates/admin/task_record_changelist.html
+++ b/prophecies/core/templates/admin/task_record_changelist.html
@@ -1,4 +1,4 @@
-{% extends 'admin/import_export/change_list_export.html' %}
+{% extends 'admin/change_list.html' %}
 {% load i18n %}
 
 {% block object-tools-items %}

--- a/prophecies/core/templates/admin/task_record_changelist.html
+++ b/prophecies/core/templates/admin/task_record_changelist.html
@@ -1,4 +1,4 @@
-{% extends 'admin/change_list.html' %}
+{% extends 'admin/import_export/change_list_export.html' %}
 {% load i18n %}
 
 {% block object-tools-items %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ django-activity-stream = "1.4.1"
 django-jsonfield = "*"
 markdown = "*"
 django-admin-autocomplete-filter = "*"
-django-import-export = "*"
+django-import-export = "2.7.1"
 
 [tool.poetry.group.dev.dependencies]
 time-machine = "*"


### PR DESCRIPTION
During the upgrade from pipenv to poetry the versions of the dependencies were not fixed. Updates caused breaking changes on import export