### PR TITLE
feat: add top paginations to task record and task record review

### DIFF
--- a/prophecies/core/admin/task_record_admin.py
+++ b/prophecies/core/admin/task_record_admin.py
@@ -37,6 +37,7 @@ class TaskRecordReviewInline(admin.TabularInline):
 class TaskRecordAdmin(ExportWithCsvStreamMixin, admin.ModelAdmin):
     resource_class = TaskRecordResource
     change_list_template = "admin/task_record_changelist.html"
+    actions_on_bottom = True
     exclude = ['metadata', 'rounds', 'link', 'status']
     readonly_fields = ['round_count', 'status_badge', 'computed_link', 'metadata_json']
     list_display = ['task_record_excerpt', 'task_with_addon', 'round_count', 'status_badge']

--- a/prophecies/core/admin/task_record_review_admin.py
+++ b/prophecies/core/admin/task_record_review_admin.py
@@ -19,6 +19,8 @@ class TaskRecordReviewResource(ExportCsvGeneratorMixin, ModelResource):
 @admin.register(TaskRecordReview)
 class TaskRecordReviewAdmin(ExportWithCsvStreamMixin, admin.ModelAdmin):
     resource_class = TaskRecordReviewResource
+    change_list_template = "admin/task_record_review_changelist.html"
+    actions_on_bottom = True
     list_display = ['review_with_details', 'task_with_addon', 'round', 'status_badge']
     list_filter = [
         AutocompleteFilterFactory('task', 'task_record__task'),

--- a/prophecies/core/templates/admin/task_record_changelist.html
+++ b/prophecies/core/templates/admin/task_record_changelist.html
@@ -1,5 +1,5 @@
 {% extends 'admin/import_export/change_list_export.html' %}
-{% load i18n %}
+{% load i18n admin_list %}
 
 {% block object-tools-items %}
   <li>
@@ -9,5 +9,10 @@
       {% endblocktranslate %}
     </a>
   </li>
+  {{ block.super }}
+{% endblock %}
+
+{% block result_list %}
+  {% pagination cl %}
   {{ block.super }}
 {% endblock %}

--- a/prophecies/core/templates/admin/task_record_review_changelist.html
+++ b/prophecies/core/templates/admin/task_record_review_changelist.html
@@ -1,0 +1,7 @@
+{% extends 'admin/change_list.html' %}
+{% load admin_list %}
+
+{% block result_list %}
+  {% pagination cl %}
+  {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
## PR description

As describe in #181 and #182, this adds a top pagination to the task record and task record review list pages. For consistency this also adds the actions to the bottom.

## Preview

![Screenshot 2024-01-16 at 17-08-52 Select task record review to change Prophecies](https://github.com/ICIJ/prophecies/assets/471176/c7dcc02b-092c-4028-8328-e8f4b1d41974)
![Screenshot 2024-01-16 at 17-08-46 Select task record to change Prophecies](https://github.com/ICIJ/prophecies/assets/471176/c88abd08-064e-4ac3-b12e-2b594836e98b)
