### PR TITLE
feat: upload media to S3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -37,6 +37,47 @@ wrapt = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.34.21"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">= 3.8"
+files = [
+    {file = "boto3-1.34.21-py3-none-any.whl", hash = "sha256:88e3baeb53ae421aabd44bb49ebdd7122b74b53b0f437b0f3e17141f6744574a"},
+    {file = "boto3-1.34.21.tar.gz", hash = "sha256:206e61ba1f8c830e5df0355606d178ad5bc970df12c4c318b021c71da410eb0c"},
+]
+
+[package.dependencies]
+botocore = ">=1.34.21,<1.35.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.10.0,<0.11.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.34.21"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">= 3.8"
+files = [
+    {file = "botocore-1.34.21-py3-none-any.whl", hash = "sha256:43274fd3f8e02573790ee76313607c60e3c15a7a0d89d24dfe4042f882f1f8c9"},
+    {file = "botocore-1.34.21.tar.gz", hash = "sha256:21983bb0473a19130192c50ec6974d55f0c4aa48a7094bcf40f7882c8b69b8f1"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = [
+    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+crt = ["awscrt (==0.19.19)"]
+
+[[package]]
 name = "certifi"
 version = "2023.11.17"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -538,6 +579,30 @@ djangorestframework = "*"
 six = "*"
 
 [[package]]
+name = "django-storages"
+version = "1.14.2"
+description = "Support for many storage backends in Django"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "django-storages-1.14.2.tar.gz", hash = "sha256:51b36af28cc5813b98d5f3dfe7459af638d84428c8df4a03990c7d74d1bea4e5"},
+    {file = "django_storages-1.14.2-py3-none-any.whl", hash = "sha256:1db759346b52ada6c2efd9f23d8241ecf518813eb31db9e2589207174f58f6ad"},
+]
+
+[package.dependencies]
+boto3 = {version = ">=1.4.4", optional = true, markers = "extra == \"s3\""}
+Django = ">=3.2"
+
+[package.extras]
+azure = ["azure-core (>=1.13)", "azure-storage-blob (>=12)"]
+boto3 = ["boto3 (>=1.4.4)"]
+dropbox = ["dropbox (>=7.2.1)"]
+google = ["google-cloud-storage (>=1.27)"]
+libcloud = ["apache-libcloud"]
+s3 = ["boto3 (>=1.4.4)"]
+sftp = ["paramiko (>=1.15)"]
+
+[[package]]
 name = "django-webpack-loader"
 version = "3.0.1"
 description = "Transparently use webpack with django"
@@ -695,6 +760,17 @@ files = [
 
 [package.extras]
 colors = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
 
 [[package]]
 name = "lazy-object-proxy"
@@ -1281,6 +1357,23 @@ requests = ">=2.0.0"
 rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
+name = "s3transfer"
+version = "0.10.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">= 3.8"
+files = [
+    {file = "s3transfer-0.10.0-py3-none-any.whl", hash = "sha256:3cdb40f5cfa6966e812209d0994f2a4709b561c88e90cf00c2696d2df4e56b2e"},
+    {file = "s3transfer-0.10.0.tar.gz", hash = "sha256:d0c8bbf672d5eebbe4e57945e23b972d963f07d82f661cabf678a5c88831595b"},
+]
+
+[package.dependencies]
+botocore = ">=1.33.2,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
+
+[[package]]
 name = "setuptools"
 version = "69.0.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1507,17 +1600,34 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.1.0"
+version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.1.0-py3-none-any.whl", hash = "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3"},
-    {file = "urllib3-2.1.0.tar.gz", hash = "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"},
+    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
+    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
+]
+
+[package.extras]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
@@ -1645,4 +1755,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4a8bc481445aba4fd1e6e6de5ec85a645bd847b2c50f9270e1270197e787303f"
+content-hash = "bb2d2391ddfa8bcf51ee4f8cacf6301ec15a9c13026baf1041fc9c235eafe614"

--- a/prophecies/core/admin/task_record_media_admin.py
+++ b/prophecies/core/admin/task_record_media_admin.py
@@ -43,7 +43,7 @@ class TaskRecordMediaAdmin(admin.ModelAdmin):
 
     @admin.display(description=_("Preview"), ordering="pk")
     def preview(self, media: TaskRecordMedia, width: int = 60):
-        src = media.file_preview_url_with_timestamp
+        src = media.file_preview_url
         src = (
             src
             if src

--- a/prophecies/core/models/task_record_media.py
+++ b/prophecies/core/models/task_record_media.py
@@ -72,9 +72,9 @@ class TaskRecordMedia(models.Model):
         return TaskRecordMedia.mime_to_media_type(self.mime_type)
 
     @property
-    def file_preview_url_with_timestamp(self):
+    def file_preview_url(self):
         if self.file and self.media_type == TaskRecordMedia.MediaType.IMAGE:
-            return f"{self.file.url}?ts={self.updated_at.timestamp()}"
+            return f"{self.file.url}"
         return None
 
     @staticmethod

--- a/prophecies/core/storages/__init__.py
+++ b/prophecies/core/storages/__init__.py
@@ -1,0 +1,1 @@
+from .s3_media_storage import S3MediaStorage

--- a/prophecies/core/storages/s3_media_storage.py
+++ b/prophecies/core/storages/s3_media_storage.py
@@ -1,5 +1,7 @@
 from storages.backends.s3boto3 import S3Boto3Storage
 
+
+# pylint: disable=abstract-method
 class S3MediaStorage(S3Boto3Storage):
     location = "private"
     default_acl = "private"

--- a/prophecies/core/storages/s3_media_storage.py
+++ b/prophecies/core/storages/s3_media_storage.py
@@ -1,0 +1,7 @@
+from storages.backends.s3boto3 import S3Boto3Storage
+
+class S3MediaStorage(S3Boto3Storage):
+    location = "private"
+    default_acl = "private"
+    file_overwrite = False
+    custom_domain = False

--- a/prophecies/core/tests/models/test_task_record_media.py
+++ b/prophecies/core/tests/models/test_task_record_media.py
@@ -37,17 +37,6 @@ class TaskRecordMediaModelTests(TestCase):
             )
         self.assertEqual(media.media_type, TaskRecordMedia.MediaType.IMAGE)
 
-    def test_file_preview_url_with_timestamp(self):
-        img_path = self.create_test_image(name="foo.jpg")
-        with open(img_path, "rb") as img_file:
-            media = TaskRecordMedia.objects.create(
-                task=self.task,
-                file=SimpleUploadedFile(
-                    img_path.name, img_file.read(), content_type="image/jpeg"
-                ),
-            )
-        self.assertIn("?ts=", media.file_preview_url_with_timestamp)
-
     def test_file_to_media_type(self):
         img_path = self.create_test_image()
         with open(img_path, "rb") as img_file:

--- a/prophecies/core/validators/task_record_media.py
+++ b/prophecies/core/validators/task_record_media.py
@@ -9,7 +9,7 @@ class MimeTypeValidator:
     messages = {"not_supported": "File type is not supported."}
 
     @staticmethod
-    def allowed_mine_types():
+    def allowed_mime_types():
         from prophecies.core.models import TaskRecordMedia
 
         return TaskRecordMedia.mime_types()

--- a/prophecies/urls.py
+++ b/prophecies/urls.py
@@ -30,4 +30,6 @@ if not settings.DJANGO_ADMIN_LOGIN:
 
 if settings.DEBUG:
     urlpatterns = urlpatterns + [path('__debug__/', include(debug_toolbar.urls)), ]
+
+if settings.MEDIA_STORAGE == 'FS':
     urlpatterns = urlpatterns + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ setuptools = "^69.0.3"
 python-magic = "^0.4.27"
 django-polymorphic = "^3.1.0"
 django-rest-polymorphic = "^0.1.10"
+boto3 = "^1.34.21"
+django-storages = {extras = ["s3"], version = "^1.14.2"}
 
 [tool.poetry.group.dev.dependencies]
 time-machine = "*"


### PR DESCRIPTION
## PR Description

This PR allow to configure S3 as a private storage for media (#192). The media are then available through a [presigned URL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html) for 3600 seconds (1h) by default. This change is transparent for users and the front as Django Storages is already generating the URL.

## Changes

The most meaningful changes are in:

* `prophecies/settings/base.py` to add the storage configuration ;
* `prophecies/core/storages/s3_media_storage.py` to define the storage.

## Usage

To enable this feature, the following environment variables must be added:

```bash
export AWS_ACCESS_KEY_ID=""
export AWS_SECRET_ACCESS_KEY=""
export AWS_STORAGE_BUCKET_NAME=""
export AWS_S3_REGION_NAME="us-east-1"
export MEDIA_STORAGE="S3"
```